### PR TITLE
Adds new z-index rules and fixes an issue when inspecting a shadow dom element

### DIFF
--- a/devtools/index.js
+++ b/devtools/index.js
@@ -3,29 +3,77 @@ function zContext() {
 		//Also see: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
 		getClosestStackingContext = function( nodeOrObject ) {
 			var node = nodeOrObject.node || nodeOrObject;
+
+			//the root element (HTML),
 			if( ! node || node.nodeName === 'HTML' ) {
 				return { node: document.documentElement, reason: 'root' };
 			}
+
 			var computedStyle = getComputedStyle( node );
+
+			// position: fixed
 			if ( computedStyle.position === 'fixed' ) {
 				return { node: node, reason: 'position: fixed' };
-			} else if ( computedStyle.zIndex !== 'auto' && computedStyle.position !== 'static' ) {
-				return { node: node, reason: 'position: ' + computedStyle.position + '; z-index: ' + computedStyle.zIndex };
-			} else if ( computedStyle.opacity !== '1' ) {
-				return { node: node, reason: 'opacity: ' + computedStyle.opacity };
-			} else if ( computedStyle.transform !== 'none' ) {
-				return { node: node, reason: 'transform: ' + computedStyle.transform };
-			} else if ( computedStyle.mixBlendMode !== 'normal' ) {
-				return { node: node, reason: 'mixBlendMode: ' + computedStyle.mixBlendMode };
-			} else if ( computedStyle.filter !== 'none' ) {
-				return { node: node, reason: 'filter: ' + computedStyle.filter };
-			} else if ( computedStyle.isolation === 'isolate' ) {
-				return { node: node, reason: 'isolation: ' + computedStyle.isolation };
-			} else if ( computedStyle.webkitOverflowScrolling === 'touch' ) {
-				return { node: node, reason: '-webkit-overflow-scrolling: touch' };
-			} else {
-				return getClosestStackingContext( { node: node.parentNode, reason: 'not a stacking context' } );
 			}
+
+			// positioned (absolutely or relatively) with a z-index value other than "auto",
+			if ( computedStyle.zIndex !== 'auto' && computedStyle.position !== 'static' ) {
+				return { node: node, reason: 'position: ' + computedStyle.position + '; z-index: ' + computedStyle.zIndex };
+			}
+
+			// elements with an opacity value less than 1.
+			if ( computedStyle.opacity !== '1' ) {
+				return { node: node, reason: 'opacity: ' + computedStyle.opacity };
+			}
+
+			// elements with a transform value other than "none"
+			if ( computedStyle.transform !== 'none' ) {
+				return { node: node, reason: 'transform: ' + computedStyle.transform };
+			}
+
+			// elements with a mix-blend-mode value other than "normal"
+			if ( computedStyle.mixBlendMode !== 'normal' ) {
+				return { node: node, reason: 'mixBlendMode: ' + computedStyle.mixBlendMode };
+			}
+
+			// elements with a filter value other than "none"
+			if ( computedStyle.filter !== 'none' ) {
+				return { node: node, reason: 'filter: ' + computedStyle.filter };
+			}
+
+			// elements with a perspective value other than "none"
+			if ( computedStyle.perspective !== 'none' ) {
+				return { node: node, reason: 'perspective: ' + computedStyle.perspective };
+			}
+
+			// elements with isolation set to "isolate"
+			if ( computedStyle.isolation === 'isolate' ) {
+				return { node: node, reason: 'isolation: ' + computedStyle.isolation };
+			}
+
+			// specifying any attribute above in will-change even if you don't specify values for these attributes directly
+			if( computedStyle.willChange !== 'auto' ) {
+				return { node: node, reason: 'willChange: ' + computedStyle.willChange };
+			}
+
+			// elements with -webkit-overflow-scrolling set to "touch"
+			if ( computedStyle.webkitOverflowScrolling === 'touch' ) {
+				return { node: node, reason: '-webkit-overflow-scrolling: touch' };
+			}
+
+			// a flex item with a z-index value other than "auto", that is the parent element display: flex|inline-flex,
+			if ( computedStyle.zIndex !== 'auto' ) {
+				var parentStyle = getComputedStyle( node.parentNode );
+				if ( parentStyle.display === 'flex' || parentStyle.display === 'inline-flex' ) {
+					return {
+						node: node,
+						reason: 'display: ' + computedStyle.display + '; z-index: ' + computedStyle.zIndex
+					};
+				}
+			}
+
+			return getClosestStackingContext( { node: node.parentNode, reason: 'not a stacking context' } );
+
 		},
 		shallowCopy = function( data ) {
 			var props = Object.getOwnPropertyNames( data );

--- a/devtools/index.js
+++ b/devtools/index.js
@@ -4,8 +4,8 @@ function zContext() {
 		getClosestStackingContext = function( nodeOrObject ) {
 			var node = nodeOrObject.node || nodeOrObject;
 
-			//the root element (HTML),
-			if( ! node || node.nodeName === 'HTML' ) {
+			//the root element (HTML)
+			if( ! node || node.nodeName === 'HTML' || node.nodeName === '#document-fragment' ) {
 				return { node: document.documentElement, reason: 'root' };
 			}
 

--- a/devtools/index.js
+++ b/devtools/index.js
@@ -87,7 +87,7 @@ function zContext() {
 			var selector, tag = element.nodeName.toLowerCase();
 			if( element.id ) {
 				selector = '#' + element.getAttribute( 'id' );
-			} else if( element.className ) {
+			} else if( element.getAttribute( 'class' ) ) {
 				selector = '.' + element.getAttribute( 'class' ).split( ' ' ).join( '.' );
 			}
 			return selector ? tag + selector : tag;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "z-context",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "A Chrome DevTools Extension that displays stacking contexts and z-index values in the elements panel",
 	"author": "gwwar",
 	"devtools_page": "devtools/index.html",


### PR DESCRIPTION
This should fix the error thrown in #2, though I'm not sure on the specifics of how shadow dom elements compare with normal contexts on the page. I'll go ahead and merge this sometime next week, and publish a new version.

@n1ywb feel free to test this earlier by:

```
cd your-checkout-folder
git clone git@github.com:gwwar/z-context.git
cd z-context
git checkout update/rules
```

- Open `chrome://extensions` in Chrome
- Click the checkbox for Developer Mode
- Click Load Unpacked Extension
- Select the folder where you cloned this project
- Open a new tab, and inspect something that uses the shadow dom
![screen shot 2017-04-27 at 5 53 47 pm](https://cloud.githubusercontent.com/assets/1270189/25510227/5d620e50-2b73-11e7-97cb-f7a7cffe5a64.png)

