### PR TITLE
Fix context display reason for flex-item

### DIFF
--- a/devtools/index.js
+++ b/devtools/index.js
@@ -67,7 +67,7 @@ function zContext() {
 				if ( parentStyle.display === 'flex' || parentStyle.display === 'inline-flex' ) {
 					return {
 						node: node,
-						reason: 'display: ' + computedStyle.display + '; z-index: ' + computedStyle.zIndex
+						reason: 'flex-item; z-index: ' + computedStyle.zIndex
 					};
 				}
 			}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "z-context",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "A Chrome DevTools Extension that displays stacking contexts and z-index values in the elements panel",
 	"author": "gwwar",
 	"devtools_page": "devtools/index.html",


### PR DESCRIPTION
<img width="485" alt="screen shot 2017-05-07 at 11 41 07 am" src="https://cloud.githubusercontent.com/assets/1270189/25783973/164c6b4c-331a-11e7-8c35-619219de2723.png">

This fixes the display reason for flex-item elements (elements whose parents have display flex|inline-flex) that have a z-index value other than "auto". Previously, the reason given was the current `display` value of the element which was confusing.