### PR TITLE
1.0.4: Fix will-change. It creates a stacking context only on opacity and transform

### DIFF
--- a/devtools/index.js
+++ b/devtools/index.js
@@ -51,8 +51,8 @@ function zContext() {
 				return { node: node, reason: 'isolation: ' + computedStyle.isolation };
 			}
 
-			// specifying any attribute above in will-change even if you don't specify values for these attributes directly
-			if( computedStyle.willChange !== 'auto' ) {
+			// transform or opacity in will-change even if you don't specify values for these attributes directly
+			if( computedStyle.willChange === 'transform' || computedStyle.willChange === 'opacity' ) {
 				return { node: node, reason: 'willChange: ' + computedStyle.willChange };
 			}
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "z-context",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "A Chrome DevTools Extension that displays stacking contexts and z-index values in the elements panel",
 	"author": "gwwar",
 	"devtools_page": "devtools/index.html",


### PR DESCRIPTION
Fixes #7. As reported by Dmitri Pisarev, currently we detect anything set to anything other than "will-change: auto". This is incorrect, as it only creates a stacking context for `transform` and `opacity`. See [code pen](https://codepen.io/gwwar/pen/eVyPZx) to test

