### PR TITLE
fix: elements with position `sticky` also form a stacking context

### DIFF
--- a/devtools/index.js
+++ b/devtools/index.js
@@ -11,9 +11,9 @@ function zContext() {
 
 			var computedStyle = getComputedStyle( node );
 
-			// position: fixed
-			if ( computedStyle.position === 'fixed' ) {
-				return { node: node, reason: 'position: fixed' };
+			// position: fixed or sticky
+			if ( computedStyle.position === 'fixed' || computedStyle.position === 'sticky' ) {
+				return { node: node, reason: 'position: ' + computedStyle.position };
 			}
 
 			// positioned (absolutely or relatively) with a z-index value other than "auto",


### PR DESCRIPTION
According to the [MDN web docs][1], elements with position `sticky` also
form a stacking context, this adds an additional check to contemplate
this case.

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context