### PR TITLE
fix: parentStackingContext of elements inside a ShadowRoot

### DIFF
--- a/devtools/index.js
+++ b/devtools/index.js
@@ -5,8 +5,13 @@ function zContext() {
 			var node = nodeOrObject.node || nodeOrObject;
 
 			//the root element (HTML)
-			if( ! node || node.nodeName === 'HTML' || node.nodeName === '#document-fragment' ) {
+			if( ! node || node.nodeName === 'HTML') {
 				return { node: document.documentElement, reason: 'root' };
+			}
+
+			// handle shadow root elements
+			if ( node.nodeName === '#document-fragment' ) {
+				return getClosestStackingContext( { node: node.host, reason: 'not a stacking context' } );
 			}
 
 			var computedStyle = getComputedStyle( node );


### PR DESCRIPTION
 parentStackingContext of elements inside a ShadowRoot is not necessarily "html"