### PR TITLE
Remove unneeded tab permissions

### DIFF
--- a/devtools/index.js
+++ b/devtools/index.js
@@ -4,7 +4,7 @@
 chrome.devtools.panels.elements.createSidebarPane(
 	"Z-Index",
 	function ( sidebar ) {
-		const port = chrome.extension.connect( { name: "Z-Context" } );
+		const port = chrome.runtime.connect( { name: "Z-Context" } );
 		// Listen for messages sent from background.js.
 		port.onMessage.addListener( function ( msg ) {
 			switch ( msg.type ) {

--- a/manifest.json
+++ b/manifest.json
@@ -5,9 +5,6 @@
 	"description": "A Chrome DevTools Extension that displays stacking contexts and z-index values in the elements panel",
 	"author": "gwwar",
 	"devtools_page": "devtools/index.html",
-	"permissions": [
-		"tabs"
-	],
 	"background": {
 		"scripts": [
 			"background.js"


### PR DESCRIPTION
This is a follow up to https://github.com/gwwar/z-context/pull/21, where I added support for inspecting iframes. Part of https://github.com/gwwar/z-context/issues/5

This PR does a few things:

- Removes the "tabs" permission from the manifest. I query the active tab, but this was unneeded. We only need to request this in the manifest if we need access to some properties of the Tab object. See: https://developer.chrome.com/docs/extensions/reference/tabs/#manifest 
- I also favored usage of `chrome.runtime.connect` over `chrome.extension.connect`, since it seems like the former is the newer API.
- Also removed a listener on port disconnect, to avoid errors after closing a tab and inspecting elements in a new tab.
