### PR TITLE
Bump version to 2.1.0 in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "z-context",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "A Chrome DevTools Extension that displays stacking contexts and z-index values in the elements panel",
 	"author": "gwwar",
 	"devtools_page": "devtools/index.html",


### PR DESCRIPTION
This updates the extension version from 2.0.0 to 2.1.0. This includes changes in https://github.com/gwwar/z-context/pull/23