### PR TITLE
Added backdrop-filter rule

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -70,6 +70,11 @@ const getClosestStackingContext = function ( node ) {
 		return { node: node, reason: `filter: ${ computedStyle.filter }` };
 	}
 
+	// elements with a backdrop-filter value other than "none".
+	if ( computedStyle.backdropFilter !== 'none' ) {
+		return { node: node, reason: `backdrop-filter: ${ computedStyle.backdropFilter }` };
+	}
+
 	// elements with a perspective value other than "none".
 	if ( computedStyle.perspective !== 'none' ) {
 		return { node: node, reason: `perspective: ${ computedStyle.perspective }` };


### PR DESCRIPTION
The Mozilla Stacking Context doc now references a `backdrop-filter` style that can also create a stacking context: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context